### PR TITLE
Fix error in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,15 +3,17 @@
 Extension trait for working with JSON values in a more convenient way.
 `JsonValueExt` offers convenient methods for interacting with `serde_json::Value` objects,
 simplifying tasks like getting, taking, inserting, traversing, and pretty-printing JSON data
-wh≈ile ensuring type safety with Serde's serialization and deserialization.
-# Provided Methods
+while ensuring type safety with Serde's serialization and deserialization.
+
+## Provided Methods
+
 - **`x_get`**: Returns a value of a specified type `T` from a JSON object using either a direct name or a pointer path.
 - **`x_take`**: Takes a value from a JSON object using a specified name or pointer path, replacing it with `Null`.
 - **`x_insert`**: Inserts a value of type `T` into a JSON object at the specified name or pointer path, creating any missing objects along the way.
 - **`x_walk`**: Traverses all properties within the JSON value tree, applying a user-provided callback function on each property.
 - **`x_pretty`**: Returns a pretty-printed string representation of the JSON value.
 
-# Usage
+## Usage
 
 This trait is intended to be used with `serde_json::Value` objects. It is particularly
 useful when you need to manipulate JSON structures dynamically or when the structure
@@ -40,5 +42,6 @@ fn example_usage(json: &mut Value) -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 ```
+
 This trait enhances the `serde_json::Value` API by adding more type-safe and convenient
 methods for manipulating JSON data in Rust.


### PR DESCRIPTION
Hey Jeremy, long time watcher of your videos and a huge fan of the new live coding content, had to check out the repo after your latest video and just noticed a stray character in the README.

I also have a linter enabled for README files so it made some other formatting changes as well, happy to revert them and just fix the error if you'd like.

Cheers,
Riley from Australia :)
